### PR TITLE
Fix an exception due to a typo in a block class declaration.

### DIFF
--- a/view/frontend/layout/backinstock_notification_index.xml
+++ b/view/frontend/layout/backinstock_notification_index.xml
@@ -28,7 +28,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="\MageSuite\BackInStock\Block\Subscriptions\History" name="backinstock.subscriptions.history" template="MageSuite_BackInStock::subscriptions/history.phtml" cacheable="false">
+            <block class="MageSuite\BackInStock\Block\Subscriptions\History" name="backinstock.subscriptions.history" template="MageSuite_BackInStock::subscriptions/history.phtml" cacheable="false">
                 <arguments>
                     <argument name="view_model" xsi:type="object">MageSuite\BackInStock\ViewModel\Subscriptions\History</argument>
                 </arguments>


### PR DESCRIPTION
Fix the following exception due to a typo in a block class declaration.

```
Magento\Framework\Config\Dom\ValidationException thrown with message "Element 'block', attribute 'class': [facet 'pattern'] The value '\MageSuite\BackInStock\Block\Subscriptions\History' is not accepted by the pattern '[A-Z][_a-zA-Z\d]*(\\[A-Z][_a-zA-Z\d]*)*'.
Line: 3256
Element 'block', attribute 'class': '\MageSuite\BackInStock\Block\Subscriptions\History' is not a valid value of the atomic type 'blockClassType'.
Line: 3256
"
```